### PR TITLE
Some tests added

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gem 'rspec'
 gem 'activesupport'
-gem 'pry'
+gem 'byebug'
+gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,10 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     coderay (1.1.0)
+    columnize (0.9.0)
     diff-lcs (1.2.5)
     i18n (0.7.0)
     json (1.8.1)
@@ -17,6 +20,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -40,7 +46,8 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
-  pry
+  byebug
+  pry-byebug
   rspec
 
 BUNDLED WITH

--- a/library_manager.rb
+++ b/library_manager.rb
@@ -1,4 +1,8 @@
+
 class LibraryManager
+  require "date"
+  FINE_RATE = 0.1      #Размер пени в процентах
+  FINE = FINE_RATE/100
 
   # 1. Бибилиотека в один момент решила ввести жесткую систему штрафов (прямо как на rubybursa :D).
   # За каждый час опоздания со здачей книги читатель вынужден заплатить пеню 0,1% от стоимости.  
@@ -12,10 +16,8 @@ class LibraryManager
   # Возвращаемое значение 
   # - пеня в центах
   def penalty price, issue_datetime
-    # решение пишем тут
-
-
-
+    res = (price * FINE * (DateTime.now.new_offset(0) - issue_datetime)*24).round
+    res > 0 ? res : 0
   end
 
   # 2. Известны годы жизни двух писателей. Год рождения, год смерти. Посчитать, могли ли они чисто 
@@ -31,10 +33,7 @@ class LibraryManager
   # Возвращаемое значение 
   # - true или false
   def could_meet_each_other? year_of_birth_first, year_of_death_first, year_of_birth_second, year_of_death_second
-    # решение пишем тут
-
-
-
+    year_of_birth_first > year_of_birth_second ? ( year_of_birth_first <  year_of_death_second) : ( year_of_birth_second < year_of_death_first )
   end
 
   # 3. Исходя из жесткой системы штрафов за опоздания со cдачей книг, читатели начали задумываться - а 
@@ -46,11 +45,7 @@ class LibraryManager
   # Возвращаемое значение 
   # - число полных дней, нак которые необходимо опоздать со здачей, чтобы пеня была равна стоимости книги.
   def days_to_buy price
-    # решение пишем тут
-
-
-
-
+    (1/FINE/24).ceil
   end
 
 
@@ -63,10 +58,27 @@ class LibraryManager
   # Возвращаемое значение 
   # - имя и фамилия автора транслитом. ("Ivan Franko")
   def author_translit ukr_name
-    # решение пишем тут
-
-
-
+    tab = { 'А'=>'A','а'=>'a','Б'=>'B','б'=>'b','В'=>'V','в'=>'v','Г'=>'H','г'=>'h',
+            'Ґ'=>'G','ґ'=>'g','Д'=>'D','д'=>'d','Е'=>'E','е'=>'e','Є'=>'Ye','є'=>'ie',
+            'Ж'=>'Zh','ж'=>'zh','З'=>'Z','з'=>'z','И'=>'Y','и'=>'y','І'=>'I','і'=>'i',
+            'Ї'=>'Yi','ї'=>'i','Й'=>'Y','й'=>'i','К'=>'K','к'=>'k','Л'=>'L','л'=>'l',
+            'М'=>'M','м'=>'m','Н'=>'N','н'=>'n','О'=>'O','о'=>'o','П'=>'P','п'=>'p',
+            'Р'=>'R','р'=>'r','С'=>'S','с'=>'s','Т'=>'T','т'=>'t','У'=>'U','у'=>'u',
+            'Ф'=>'F','ф'=>'f','Х'=>'Kh','х'=>'kh','Ц'=>'Ts','ц'=>'ts','Ч'=>'Ch','ч'=>'ch',
+            'Ш'=>'Sh','ш'=>'sh','Щ'=>'Shch','щ'=>'shch','Ю'=>'Yu','ю'=>'iu','Я'=>'Ya',
+            'я'=>'ia', '’'=>'','ь'=>''}
+    res = ''
+#    ukr_name.each_char {|c| res += (tab.has_key?(c) ? tab[c] : c)}
+    prev = ''
+    ukr_name.each_char do |c|
+      if (prev == 'З' || prev == 'з') && (c == 'г') then
+        res += 'gh'
+      else
+        res += (tab.has_key?(c) ? tab[c] : c)
+      end
+      prev = c
+    end
+    res
   end
 
   #5. Читатели любят дочитывать книги во что-бы то ни стало. Необходимо помочь им просчитать сумму штрафа, 
@@ -82,9 +94,9 @@ class LibraryManager
   # Возвращаемое значение 
   # - Пеня в центах или 0 при условии что читатель укладывается в срок здачи.
   def penalty_to_finish price, issue_datetime, pages_quantity, current_page, reading_speed
-    # решение пишем тут
-
-
+    exp = DateTime.now.new_offset(0) + (pages_quantity - current_page).to_f / reading_speed / 24
+    res = (price * FINE * (exp - issue_datetime)*24)
+    res > 0 ? res.round : 0
   end
 
 end

--- a/library_manager_spec.rb
+++ b/library_manager_spec.rb
@@ -89,6 +89,18 @@ describe LibraryManager do
       expect(res).to eq true
     end
 
+    it "meet each other, the second was born immediately after first died" do
+      res = LibraryManager.new.could_meet_each_other?(1900, 1950, 1950, 1980)
+
+      expect(res).to eq false
+    end
+
+    it "meet each other, the first was born immediately after the second died" do
+      res = LibraryManager.new.could_meet_each_other?(1900, 1950, 1850, 1900)
+
+      expect(res).to eq false
+    end
+
   end
 
 
@@ -129,6 +141,32 @@ describe LibraryManager do
 
       expect(res).to eq "Hryhorii Kvitka-Osnov'ianenko"
     end
+
+    it 'should return words according to http://zakon4.rada.gov.ua/laws/show/55-2010-%D0%BF' do
+        test_dim = [ ["Алушта", "Alushta"], ["Андрій", "Andrii"], ["Борщагівка", "Borshchahivka"], ["Борисенко", "Borysenko"], 
+        ["Вінниця", "Vinnytsia"], ["Володимир", "Volodymyr"], ["Гадяч", "Hadiach"], ["Богдан", "Bohdan"], ["Згурський", "Zghurskyi"], 
+        ["Ґалаґан", "Galagan"], ["Ґорґани", "Gorgany"], ["Донецьк", "Donetsk"], ["Дмитро", "Dmytro"], ["Рівне", "Rivne"], 
+        ["Олег", "Oleh"], ["Есмань", "Esman"], ["Єнакієве", "Yenakiieve"], ["Гаєвич", "Haievych"], ["Короп’є", "Koropie"], 
+        ["Житомир", "Zhytomyr"], ["Жанна", "Zhanna"], ["Жежелів", "Zhezheliv"], ["Закарпаття", "Zakarpattia"], 
+        ["Казимирчук", "Kazymyrchuk"], ["Медвин", "Medvyn"], ["Михайленко", "Mykhailenko"], ["Іванків", "Ivankiv"], 
+        ["Іващенко", "Ivashchenko"], ["Їжакевич", "Yizhakevych"], ["Кадиївка", "Kadyivka"], ["Мар’їне", "Marine"], 
+        ["Йосипівка", "Yosypivka"], ["Стрий", "Stryi"], ["Олексій", "Oleksii"], ["Київ", "Kyiv"], ["Коваленко", "Kovalenko"], 
+        ["Лебедин", "Lebedyn"], ["Леонід", "Leonid"], ["Миколаїв", "Mykolaiv"], ["Маринич", "Marynych"], ["Ніжин", "Nizhyn"], 
+        ["Наталія", "Nataliia"], ["Одеса", "Odesa"], ["Онищенко", "Onyshchenko"], ["Полтава", "Poltava"], ["Петро", "Petro"], 
+        ["Решетилівка", "Reshetylivka"], ["Рибчинський", "Rybchynskyi"], ["Суми", "Sumy"], ["Соломія", "Solomiia"], 
+        ["Тернопіль", "Ternopil"], ["Троць", "Trots"], ["Ужгород", "Uzhhorod"], ["Уляна", "Uliana"], ["Фастів", "Fastiv"], 
+        ["Філіпчук", "Filipchuk"], ["Харків", "Kharkiv"], ["Христина", "Khrystyna"], ["Біла Церква", "Bila Tserkva"], ["Стеценко", "Stetsenko"], 
+        ["Чернівці", "Chernivtsi"], ["Шевченко", "Shevchenko"], ["Шостка", "Shostka"], ["Кишеньки", "Kyshenky"], 
+        ["Щербухи", "Shcherbukhy"], ["Гоща", "Hoshcha"], ["Гаращенко", "Harashchenko"], ["Юрій", "Yurii"], 
+        ["Корюківка", "Koriukivka"], ["Яготин", "Yahotyn"], ["Ярошенко", "Yaroshenko"], ["Костянтин", "Kostiantyn"], 
+        ["Знам’янка", "Znamianka"], ["Феодосія", "Feodosiia"]]
+
+        0.upto(test_dim.size-1) do |i|
+          res = LibraryManager.new.author_translit(test_dim[i][0])
+          expect(res).to eq test_dim[i][1]
+        end
+
+      end
 
   end
 


### PR DESCRIPTION
I've spent some time parsing example table. Maybe this work will be useful for others.
Also additional spec catches this exception from transliteration rule:

Буквосполучення "зг" відтворюється латиницею як "zgh" 
             (наприклад,  Згорани - Zghorany, Розгон - Rozghon) на 
             відміну від "zh" -  відповідника  української  літери 
             "ж".
